### PR TITLE
Additional pixel format parameters for clipboard.ts -> readImage()

### DIFF
--- a/src/api/clipboard.ts
+++ b/src/api/clipboard.ts
@@ -1,5 +1,5 @@
 import { sendMessage } from '../ws/websocket';
-import { base64ToBytesArray, arrayBufferToBase64 } from '../helpers';
+import { arrayBufferToBase64 } from '../helpers';
 import type { ClipboardImage } from '../types/api/clipboard';
 import type { ClipboardFormat } from '../types/enums';
 
@@ -11,19 +11,75 @@ export function readText(): Promise<string> {
     return sendMessage('clipboard.readText');
 };
 
-export function readImage(): Promise<ClipboardImage | null> {
-    return new Promise((resolve: any, reject: any) => {
-        sendMessage('clipboard.readImage')
-        .then((image: any) => {
-            if(image) {
-                image.data = base64ToBytesArray(image.data);
-            }
-            resolve(image);
-        })
-        .catch((error: any) => {
-            reject(error);
-        });
-    });
+export function readImage(format: string = ''): Promise < ClipboardImage | null > {
+	return new Promise((resolve: any, reject: any) => {
+		sendMessage('clipboard.readImage')
+			.then((image: any) => {
+				if (image) {
+					const binaryData = window.atob(image.data);
+					let numOfBytes: number = image.bpp == 32 ? 4 : 3;
+					let len: number, pattern: number[], bytes: Uint8Array;
+
+					switch (format.toLowerCase()) {
+						case 'rgb':
+							len = image.width * image.height * 3;
+							pattern = [0, 1, 2];
+							break;
+
+						case 'rgba':
+							len = image.width * image.height * 4;
+							pattern = [0, 1, 2, 3];
+							break;
+
+						case 'argb':
+							len = image.width * image.height * 4;
+							pattern = [3, 0, 1, 2];
+							break;
+
+						case 'bgra':
+							len = image.width * image.height * 4;
+							pattern = [2, 1, 0, 3];
+							break;
+
+						default:
+							len = binaryData.length;
+							bytes = new Uint8Array(len);
+							for (let i = 0; i < len; i++) {
+								bytes[i] = binaryData.charCodeAt(i);
+							}
+							image.data = bytes;
+							resolve(image);
+					}
+					bytes = new Uint8Array(len);
+					let isLittleEndian: boolean = new Uint8Array(new Uint32Array([0x000000ff]).buffer)[0] == 0xff;
+					let byteA: number, byteB: number, byteC: number, byteD: number, uint32: number;
+					let rgba: number[] = [];
+					let outIndex: number = 0;
+					for (let i = 0; i < binaryData.length; i += numOfBytes) {
+						byteA = binaryData.charCodeAt(i);
+						byteB = binaryData.charCodeAt(i + 1);
+						byteC = binaryData.charCodeAt(i + 2);
+						byteD = numOfBytes == 4 ? binaryData.charCodeAt(i + 3) : 0xff;
+						if (isLittleEndian) {
+							uint32 = ((byteD << 24) | (byteC << 16) | (byteB << 8) | byteA) >>> 0;
+						} else {
+							uint32 = ((byteA << 24) | (byteB << 16) | (byteC << 8) | byteD) >>> 0;
+						}
+
+						rgba = [(uint32 >> image.redShift) & 0xff, (uint32 >> image.greenShift) & 0xff, (uint32 >> image.blueShift) & 0xff, (uint32 >> image.alphaShift) & 0xff]
+						pattern.forEach((el, index) => {
+							bytes[index + outIndex] = rgba[el];
+						});
+						outIndex += pattern.length;
+					}
+					image.data = bytes;
+				}
+				resolve(image);
+			})
+			.catch((error: any) => {
+				reject(error);
+			});
+	});
 };
 
 export function writeText(data: string): Promise<void> {


### PR DESCRIPTION
As the output pixel format of the underlying c++ [clipboard](https://github.com/neutralinojs/neutralinojs/tree/main/lib/clip) implementation is platform dependent, trying to draw the contents of the returned data array directly onto a canvas results in wrong colors, because on e.g. Windows the default format is BGRA, whereas canvas' [ImageData](https://developer.mozilla.org/en-US/docs/Web/API/ImageData) expects RGBA.

So a simple neutralinojs app, which waits for clipboard content and paints a canvas:
```javascript
let img = document.createElement("img");
img.onload = () => {
	document.body.appendChild(img);
	setTimeout(checkClipboard, 1000);
}
img.src = "https://picsum.photos/id/11/400/200";

async function checkClipboard() {
	let image = await Neutralino.clipboard.readImage();
	if (image) {
		let canvas = document.createElement("canvas");
		let ctx = canvas.getContext("2d");
		canvas.width = image.width;
		canvas.height = image.height;
		ctx.putImageData(new ImageData(new Uint8ClampedArray(image.data), canvas.width, canvas.height), 0, 0);
		document.body.appendChild(canvas);
		return;
	}
	setTimeout(checkClipboard, 1000);
}
```

results in:
![screenshot](https://github.com/user-attachments/assets/3e5381ec-7f04-4e4a-ab13-e91304f24e9b)

This pull request aims to come around this issue by introducing a new parameter **format** for the drawImage() function, which let's you select the desired pixel format among RGBA, BGRA, ARGB, RGB. If no parameter is given, it will transfer the bytes as is.